### PR TITLE
Fix displaying test ads on iOS devices

### DIFF
--- a/src/ios/CDVAdMob.m
+++ b/src/ios/CDVAdMob.m
@@ -410,7 +410,7 @@
 
     if (self.isTesting) {
         NSString* deviceId = [self __getAdMobDeviceId];
-        request.testDevices = @[ kGADSimulatorID, deviceId ];
+        request.testDevices = @[ kGADSimulatorID, deviceId, [deviceId lowercaseString] ];
         NSLog(@"request.testDevices: %@", deviceId);
     }
     if (self.adExtras) {


### PR DESCRIPTION
This closes #13 where it's impossible to test ads on the iOS devices due to the fact that testDevices should be set to lowercase according to the debug message.