### PR TITLE
[Android] fixing temporary auto show of interstitial

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,11 @@ cordova plugin add cordova-plugin-admob-free --save
 
 ## Usage
 
-### 1. Ceate Ad Unit ID for your banner and interstitial.
+### 1. Create Ad Unit ID for your banner and interstitial.
 
 Go to [AdMob portal](https://www.google.com/admob/), click "Monetize a new app" button to create new ad unit.
 
-### 2. Define configiration for differrent platforms.
+### 2. Define configuration for different platforms.
 
 ```javascript
 var admobid = {};
@@ -73,7 +73,7 @@ AdMob.setOptions({
   overlap: true,  // set to true, to allow banner overlap webview
   offsetTopBar: false,  // set to true to avoid ios7 status bar overlap
   isTesting: false,  // receiving test ad
-  autoShow: false,  // auto show interstitial ad when loaded
+  autoShow: false  // auto show interstitial ad when loaded
 });
 ```
 
@@ -101,7 +101,7 @@ AdMob.showAd(true);
 // prepare and load ad resource in background, e.g. at the beginning of game level
 AdMob.prepareInterstitial({
   interstitialId: admobid.interstitial,
-  autoShow: false,
+  autoShow: false
 });
 
 // show the interstitial later, e.g. at end of game level
@@ -133,7 +133,7 @@ AdMob.destroyBannerView();
 AdMob.showAd();
 
 // use interstitial
-AdMob.prepareInterstitial(adId/options, success, fail);
+AdMob.prepareInterstitial(options, success, fail);
 AdMob.showInterstitial();
 // low-level methods
 AdMob.createInterstitialView();

--- a/example/www/js/index.js
+++ b/example/www/js/index.js
@@ -21,7 +21,7 @@ document.addEventListener('deviceready', function() {
   });
 
   AdMob.prepareInterstitial({
-    adId: admobid.interstitial,
+    interstitialAdId: admobid.interstitial,
     autoShow: false,
   })
 
@@ -45,7 +45,7 @@ document.addEventListener('onDismissInterstitialAd', function(event) {
   console.log(event)
 
   AdMob.prepareInterstitial({
-    adId: admobid.interstitial,
+    interstitialAdId: admobid.interstitial,
     autoShow: false,
   })
 })

--- a/src/android/AdMob.java
+++ b/src/android/AdMob.java
@@ -77,7 +77,6 @@ public class AdMob extends CordovaPlugin {
 
     private boolean autoShowBanner = true;
     private boolean autoShowInterstitial = true;
-    private boolean autoShowInterstitialTemp = false;        //if people call it when it's not ready
 
     private boolean bannerVisible = false;
     private boolean isGpsAvailable = false;
@@ -481,17 +480,18 @@ public class AdMob extends CordovaPlugin {
         cordova.getActivity().runOnUiThread(new Runnable() {
             @Override
             public void run() {
-
+                
                 if (interstitialAd.isLoaded()) {
                     interstitialAd.show();
-                } else {
-                    Log.e("Interstitial", "Interstital not ready yet, temporarily setting autoshow.");
-                    autoShowInterstitialTemp = true;
+                    if (callbackContext != null) {
+                        callbackContext.success();
+                    }
+                } else if (!autoShowInterstitial) {
+                    if (callbackContext != null) {
+                        callbackContext.error("Interstital not ready yet");
+                    }
                 }
-
-                if (callbackContext != null) {
-                    callbackContext.success();
-                }
+                
             }
         });
 
@@ -591,9 +591,6 @@ public class AdMob extends CordovaPlugin {
 
             if (autoShowInterstitial) {
                 executeShowInterstitialAd(true, null);
-            } else if (autoShowInterstitialTemp) {
-                executeShowInterstitialAd(true, null);
-                autoShowInterstitialTemp = false;
             }
         }
 


### PR DESCRIPTION
autoShowInterstitialTemp is temporarily activating auto show even though auto show is set to false in the config, which may cause ads to pop up in an untimely fashion.
this PR is erroring back to the app when an ad is not ready in order to let the app decide what to do (listen for onReceiveInterstitialAd or skip the ad for instance)