### PR TITLE
Add space for non-overlapping bottom banners on iPhone X

### DIFF
--- a/src/ios/CDVAdMob.m
+++ b/src/ios/CDVAdMob.m
@@ -531,7 +531,7 @@
     NSLog(@"__createBanner");
 
     // set background color to black
-    //self.webView.superview.backgroundColor = [UIColor blackColor];
+    self.webView.superview.backgroundColor = [UIColor blackColor];
     //self.webView.superview.tintColor = [UIColor whiteColor];
 
     if (!self.bannerView){
@@ -711,6 +711,12 @@
                     bf.origin.y = wf.size.height - bf.size.height; // banner is subview of webview
                 } else {
                     bf.origin.y = pr.size.height - bf.size.height;
+
+                    if (@available(iOS 11.0, *)) {
+                        bf.origin.y -= parentView.safeAreaInsets.bottom;
+                        bf.size.width = wf.size.width - parentView.safeAreaInsets.left - parentView.safeAreaInsets.right;
+                        wf.size.height -= parentView.safeAreaInsets.bottom;
+                    }
                 }
             }
 


### PR DESCRIPTION
This PR adds basic support for iPhone X. Please note the following:
- Only bottom banners are affected that don't overlap the WebView.
- I don't have an Obj C background. So: Please look at the changes carefully. 
- The idea is based on https://github.com/appfeel/admob-google-cordova/commit/0bdea388a25cb59b887b5a99847470c76097cb81
- I added a black background for the webView's superview. Otherwise, the bottom part would be white which - in my opinion - doesn't look that great.

## How did I test it?
Unfortunately, I don't have a physical iPhone X for testing. All tests were made in the iOS simulator with the test ad ID provided by Google.

Below, you can find a few screenshots. I hope this PR will be useful for you. :smiley:

![iphone-x-portrait](https://user-images.githubusercontent.com/8061217/37594907-fe13d082-2b76-11e8-93c4-2b825692f29d.png)
![iphone-x-landscape](https://user-images.githubusercontent.com/8061217/37594906-fdf31234-2b76-11e8-9381-3c8328c5ee13.png)
![iphone-6s-portrait](https://user-images.githubusercontent.com/8061217/37594904-fdd1e0be-2b76-11e8-8828-b6dd89a7de60.png)

