### PR TITLE
Add filenames to src attr to copy source-files using cordova-android@7.x

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -45,9 +45,12 @@
             </feature>
         </config-file>
 
-        <source-file src="src/android/banner" target-dir="src/name/ratson/cordova/admob" />
-        <source-file src="src/android/interstitial" target-dir="src/name/ratson/cordova/admob" />
-        <source-file src="src/android/rewardvideo" target-dir="src/name/ratson/cordova/admob" />
+        <source-file src="src/android/banner/BannerExecutor.java" target-dir="src/name/ratson/cordova/admob/banner" />
+        <source-file src="src/android/banner/BannerListener.java" target-dir="src/name/ratson/cordova/admob/banner" />
+        <source-file src="src/android/interstitial/InterstitialExecutor.java" target-dir="src/name/ratson/cordova/admob/interstitial" />
+        <source-file src="src/android/interstitial/InterstitialListener.java" target-dir="src/name/ratson/cordova/admob/interstitial" />
+        <source-file src="src/android/rewardvideo/RewardVideoExecutor.java" target-dir="src/name/ratson/cordova/admob/rewardvideo" />
+        <source-file src="src/android/rewardvideo/RewardVideoListener.java" target-dir="src/name/ratson/cordova/admob/rewardvideo" />
 
         <source-file src="src/android/AbstractExecutor.java" target-dir="src/name/ratson/cordova/admob" />
         <source-file src="src/android/Actions.java" target-dir="src/name/ratson/cordova/admob" />


### PR DESCRIPTION
Files are not getting copied to target-dir when src attribute has directory path. This happens with cordova-android@7.0 (default with cordova@8) or above.

This might be the cause of issues #150 and #162 throwing error in the build phase.

This fix does not break compatibility with previous cordova and cordova-android versions. I have tested with this fix in the following cordova setups. It didn't throw any errors.

- in cordova@7.1 using cordova-android@6.4 and cordova-android@7.1
- in cordova@8.0 using cordova-android@6.4 and cordova-android@7.1

I use plain cordova. Not ionic or phonegap build. It would be helpful if someone with ionic or phonegap build experience test and confirm whether this fix is working or not.
