### PR TITLE
Fix not showing production ads on iOS

### DIFF
--- a/src/ios/CDVAdMob.m
+++ b/src/ios/CDVAdMob.m
@@ -576,11 +576,14 @@
             request.gender = kGADGenderUnknown;
         }
     }
-    if ([self.forChild caseInsensitiveCompare:@"yes"] == NSOrderedSame) {
-        [request tagForChildDirectedTreatment:YES];
-    } else if ([self.forChild caseInsensitiveCompare:@"no"] == NSOrderedSame) {
-        [request tagForChildDirectedTreatment:NO];
-    }
+
+    if (self.forChild != nil) {
+        if ([self.forChild caseInsensitiveCompare:@"yes"] == NSOrderedSame) {
+            [request tagForChildDirectedTreatment:YES];
+        } else if ([self.forChild caseInsensitiveCompare:@"no"] == NSOrderedSame) {
+            [request tagForChildDirectedTreatment:NO];
+        }
+    }    
 
     return request;
 }


### PR DESCRIPTION
I had the following problem: When testing ads using the iOS simulator and also when using the AdMob Test ID provided by Google, ads did show correctly. But as soon as I added a production banner ID, suddenly there was only a blank space where the ad should have been. The reason for that is the "forChild" setting: If ``` self.forChild ``` is nil, the first if statement actually returns true (see e.g. https://stackoverflow.com/questions/5466738/iphone-comparing-a-nil-nsstring-with-another-valued-nsstring-returns-nsordered ). This PR adds a check for this situation.