### PR TITLE
iOS: Fixes user interaction in top of screen with banner at bottom.

### DIFF
--- a/src/ios/CDVAdMob.m
+++ b/src/ios/CDVAdMob.m
@@ -728,6 +728,7 @@
             bf.origin.x = (pr.size.width - bf.size.width) * 0.5f;
 
             self.bannerView.frame = bf;
+            self.bannerView.bounds = bf;
 
             //NSLog(@"x,y,w,h = %d,%d,%d,%d", (int) bf.origin.x, (int) bf.origin.y, (int) bf.size.width, (int) bf.size.height );
         }


### PR DESCRIPTION
Bottom banner on iOS version leaves an unclickable region in the top of the screen with the size of the banner using cordova@8.0.0, cordova-ios@4.5.4.

In this example we cannot click the back button because the ad is making the top area unclickable, also the ad at bottom does not respond, if we click it, it does nothing.

With this fix it works properly in iOS 11 with the specified cordova versions and the ad opens properly.

Example view:

![cordova admob plugin not working in ios with cordova 7](https://user-images.githubusercontent.com/5766710/39625995-63b67686-4fa0-11e8-9c1b-2e68c6de7256.png)

Code snippet of how we show the ad

```
const bannerConfig: AdMobFreeBannerConfig = {
    // add your config here
    id: "your-ad-id-here",
    autoShow: true,
    size: "LARGE_BANNER"
};

if (this.admobFree) {

    if (this.admobFree.banner) {

        this.admobFree.banner.config(bannerConfig);
        this.admobFree.banner.prepare()
            .then(() => {
                // banner Ad is ready
                // if we set autoShow to false, then we will need to call the show method here
            });

    }

}
```
