### PR TITLE
Remove iOS 7 Hack & Black Superview

### DIFF
--- a/src/ios/CDVAdMob.m
+++ b/src/ios/CDVAdMob.m
@@ -8,6 +8,7 @@
 #import "MainViewController.h"
 
 
+
 @interface CDVAdMob()
 
 - (void) __setOptions:(NSDictionary*) options;
@@ -105,7 +106,7 @@
     isRewardedVideoLoading = false;
     rewardedVideoLock = nil;
 
-    srand((unsigned int)time(NULL));  
+    srand((unsigned int)time(NULL));
 }
 
 - (void) setOptions:(CDVInvokedUrlCommand *)command {
@@ -740,7 +741,6 @@
 }
 
 - (void)deviceOrientationChange:(NSNotification *)notification {    
-    
     [self resizeViews];
 }
 

--- a/src/ios/CDVAdMob.m
+++ b/src/ios/CDVAdMob.m
@@ -8,7 +8,6 @@
 #import "MainViewController.h"
 
 
-
 @interface CDVAdMob()
 
 - (void) __setOptions:(NSDictionary*) options;
@@ -106,7 +105,7 @@
     isRewardedVideoLoading = false;
     rewardedVideoLock = nil;
 
-    srand((unsigned int)time(NULL));
+    srand((unsigned int)time(NULL));  
 }
 
 - (void) setOptions:(CDVInvokedUrlCommand *)command {
@@ -531,7 +530,7 @@
     NSLog(@"__createBanner");
 
     // set background color to black
-    self.webView.superview.backgroundColor = [UIColor blackColor];
+    //self.webView.superview.backgroundColor = [UIColor blackColor];
     //self.webView.superview.tintColor = [UIColor whiteColor];
 
     if (!self.bannerView){
@@ -669,9 +668,10 @@
     //NSLog(@"super view: %d x %d", (int)pr.size.width, (int)pr.size.height);
 
     // iOS7 Hack, handle the Statusbar
-    BOOL isIOS7 = ([[UIDevice currentDevice].systemVersion floatValue] >= 7) && ([[UIDevice currentDevice].systemVersion floatValue] < 11);
-    CGRect sf = [[UIApplication sharedApplication] statusBarFrame];
-    CGFloat top = isIOS7 ? MIN(sf.size.height, sf.size.width) : 0.0;
+    //BOOL isIOS7 = ([[UIDevice currentDevice].systemVersion floatValue] >= 7);
+    //CGRect sf = [[UIApplication sharedApplication] statusBarFrame];
+    //CGFloat top = isIOS7 ? MIN(sf.size.height, sf.size.width) : 0.0;
+    float top = 0.0;
 
     if(! self.offsetTopBar) top = 0.0;
 
@@ -739,7 +739,8 @@
     //NSLog(@"superview: %d x %d, webview: %d x %d", (int) pr.size.width, (int) pr.size.height, (int) wf.size.width, (int) wf.size.height );
 }
 
-- (void)deviceOrientationChange:(NSNotification *)notification {
+- (void)deviceOrientationChange:(NSNotification *)notification {    
+    
     [self resizeViews];
 }
 

--- a/src/ios/CDVAdMob.m
+++ b/src/ios/CDVAdMob.m
@@ -740,7 +740,7 @@
     //NSLog(@"superview: %d x %d, webview: %d x %d", (int) pr.size.width, (int) pr.size.height, (int) wf.size.width, (int) wf.size.height );
 }
 
-- (void)deviceOrientationChange:(NSNotification *)notification {    
+- (void)deviceOrientationChange:(NSNotification *)notification {
     [self resizeViews];
 }
 


### PR DESCRIPTION
The following changes address some concerns I had as mentioned in issue #186 and issue #218 .  This also solves the problem @joe-scotto is having in issue #228 .  I am still working on how to add a black colored area under the bottom safe area on the iphone x, but I am very inexperienced in objective c programming.  My thought is that an addition view needs to be created to fill this area (similar to bannerView, but lets name it "safeAreaView").  We would set the background of this view to black as it looks the nicesest.  The view can then be positioned and turned on/off as needed when we shift the banner and webview up in the resizeViews function.  I have no idea how to go about creating an additional view so some help would be needed here.