### PR TITLE
Multiple iPhone X & iOs11 Fixes

### DIFF
--- a/src/ios/CDVAdMob.h
+++ b/src/ios/CDVAdMob.h
@@ -1,6 +1,7 @@
 #import <Cordova/CDV.h>
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
+#import <Cordova/CDVPlugin.h>
 
 #import <GoogleMobileAds/GADAdSize.h>
 #import <GoogleMobileAds/GADBannerView.h>
@@ -23,8 +24,9 @@
 
 // This version of the AdMob plugin has been tested with Cordova version 2.5.0.
 
-
 @interface CDVAdMob : CDVPlugin <GADBannerViewDelegate, GADInterstitialDelegate, GADRewardBasedVideoAdDelegate> {
+	@protected    
+    UIView* _safeAreaBackgroundView; 
 }
 
 @property(nonatomic, retain) GADBannerView *bannerView;

--- a/src/ios/CDVAdMob.m
+++ b/src/ios/CDVAdMob.m
@@ -8,6 +8,7 @@
 #import "MainViewController.h"
 
 
+
 @interface CDVAdMob()
 
 - (void) __setOptions:(NSDictionary*) options;
@@ -105,7 +106,7 @@
     isRewardedVideoLoading = false;
     rewardedVideoLock = nil;
 
-    srand((unsigned int)time(NULL));  
+    srand((unsigned int)time(NULL));
 }
 
 - (void) setOptions:(CDVInvokedUrlCommand *)command {
@@ -740,7 +741,6 @@
 }
 
 - (void)deviceOrientationChange:(NSNotification *)notification {    
-    
     [self resizeViews];
 }
 

--- a/src/ios/CDVAdMob.m
+++ b/src/ios/CDVAdMob.m
@@ -8,7 +8,6 @@
 #import "MainViewController.h"
 
 
-
 @interface CDVAdMob()
 
 - (void) __setOptions:(NSDictionary*) options;
@@ -107,6 +106,8 @@
     rewardedVideoLock = nil;
 
     srand((unsigned int)time(NULL));
+
+    [self initializeSafeAreaBackgroundView];
 }
 
 - (void) setOptions:(CDVInvokedUrlCommand *)command {
@@ -663,6 +664,31 @@
     }
 }
 
+- (void) initializeSafeAreaBackgroundView
+{
+    if (! bannerOverlap && ! bannerAtTop){    	
+    	if (@available(iOS 11.0, *)) {
+    		
+    		UIView* parentView = self.bannerOverlap ? self.webView : [self.webView superview];
+    		CGRect pr = self.webView.superview.bounds;
+
+			CGRect safeAreaFrame = CGRectMake(0, 0, 0, 0);
+
+    		safeAreaFrame.origin.y = pr.size.height - parentView.safeAreaInsets.bottom;
+    		safeAreaFrame.size.width = pr.size.width;
+    		safeAreaFrame.size.height = parentView.safeAreaInsets.bottom;
+
+    		
+    		_safeAreaBackgroundView = [[UIView alloc] initWithFrame:safeAreaFrame];
+    		_safeAreaBackgroundView.backgroundColor = [UIColor blackColor];
+    		_safeAreaBackgroundView.autoresizingMask = (UIViewAutoresizingFlexibleWidth  | UIViewAutoresizingFlexibleBottomMargin);
+    		_safeAreaBackgroundView.autoresizesSubviews = YES;
+
+    		[self.webView.superview addSubview:_safeAreaBackgroundView];
+    	}    	
+	}
+}
+
 - (void)resizeViews {
     // Frame of the main container view that holds the Cordova webview.
     CGRect pr = self.webView.superview.bounds, wf = pr;
@@ -674,7 +700,7 @@
     //CGFloat top = isIOS7 ? MIN(sf.size.height, sf.size.width) : 0.0;
     float top = 0.0;
 
-    if(! self.offsetTopBar) top = 0.0;
+    //if(! self.offsetTopBar) top = 0.0;
 
     wf.origin.y = top;
     wf.size.height = pr.size.height - top;
@@ -720,6 +746,14 @@
                         bf.origin.y -= parentView.safeAreaInsets.bottom;
                         bf.size.width = wf.size.width - parentView.safeAreaInsets.left - parentView.safeAreaInsets.right;
                         wf.size.height -= parentView.safeAreaInsets.bottom;
+
+                        CGRect saf = _safeAreaBackgroundView.frame;
+                        saf.origin.y = pr.size.height - parentView.safeAreaInsets.bottom;
+    					saf.size.width = pr.size.width;
+    					saf.size.height = parentView.safeAreaInsets.bottom;
+
+    					_safeAreaBackgroundView.frame = saf;
+    					_safeAreaBackgroundView.bounds = saf;
                     }
                 }
             }
@@ -740,7 +774,8 @@
     //NSLog(@"superview: %d x %d, webview: %d x %d", (int) pr.size.width, (int) pr.size.height, (int) wf.size.width, (int) wf.size.height );
 }
 
-- (void)deviceOrientationChange:(NSNotification *)notification {
+- (void)deviceOrientationChange:(NSNotification *)notification {    
+    
     [self resizeViews];
 }
 

--- a/src/ios/CDVAdMob.m
+++ b/src/ios/CDVAdMob.m
@@ -717,12 +717,6 @@
 
         CGRect bf = self.bannerView.frame;
 
-        
-    	//If the ad is not showing turn the safeArea Background off
-        if(self.bannerView.hidden && ! _safeAreaBackgroundView.hidden){
-        	_safeAreaBackgroundView.hidden = true;
-        }
-
         // If the ad is not showing or the ad is hidden, we don't want to resize anything.
         UIView* parentView = self.bannerOverlap ? self.webView : [self.webView superview];
         BOOL adIsShowing = ([self.bannerView isDescendantOfView:parentView]) && (! self.bannerView.hidden);
@@ -775,7 +769,13 @@
             self.bannerView.bounds = bf;
 
             //NSLog(@"x,y,w,h = %d,%d,%d,%d", (int) bf.origin.x, (int) bf.origin.y, (int) bf.size.width, (int) bf.size.height );
-        }
+        } else {
+	   //Hide safe area background if visibile and banner ad does not exist    
+    	   _safeAreaBackgroundView.hidden = true;
+	}	
+    } else {
+	//Hide safe area background if visibile and banner ad does not exist    
+    	_safeAreaBackgroundView.hidden = true;
     }
 
     self.webView.frame = wf;

--- a/src/ios/CDVAdMob.m
+++ b/src/ios/CDVAdMob.m
@@ -666,27 +666,26 @@
 
 - (void) initializeSafeAreaBackgroundView
 {
-    if (! bannerOverlap && ! bannerAtTop){    	
-    	if (@available(iOS 11.0, *)) {
-    		
-    		UIView* parentView = self.bannerOverlap ? self.webView : [self.webView superview];
-    		CGRect pr = self.webView.superview.bounds;
+   	if (@available(iOS 11.0, *)) {
+		
+		UIView* parentView = self.bannerOverlap ? self.webView : [self.webView superview];
+		CGRect pr = self.webView.superview.bounds;
 
-			CGRect safeAreaFrame = CGRectMake(0, 0, 0, 0);
+		CGRect safeAreaFrame = CGRectMake(0, 0, 0, 0);
 
-    		safeAreaFrame.origin.y = pr.size.height - parentView.safeAreaInsets.bottom;
-    		safeAreaFrame.size.width = pr.size.width;
-    		safeAreaFrame.size.height = parentView.safeAreaInsets.bottom;
+		safeAreaFrame.origin.y = pr.size.height - parentView.safeAreaInsets.bottom;
+		safeAreaFrame.size.width = pr.size.width;
+		safeAreaFrame.size.height = parentView.safeAreaInsets.bottom;
 
-    		
-    		_safeAreaBackgroundView = [[UIView alloc] initWithFrame:safeAreaFrame];
-    		_safeAreaBackgroundView.backgroundColor = [UIColor blackColor];
-    		_safeAreaBackgroundView.autoresizingMask = (UIViewAutoresizingFlexibleWidth  | UIViewAutoresizingFlexibleBottomMargin);
-    		_safeAreaBackgroundView.autoresizesSubviews = YES;
+		
+		_safeAreaBackgroundView = [[UIView alloc] initWithFrame:safeAreaFrame];
+		_safeAreaBackgroundView.backgroundColor = [UIColor blackColor];
+		_safeAreaBackgroundView.autoresizingMask = (UIViewAutoresizingFlexibleWidth  | UIViewAutoresizingFlexibleBottomMargin);
+		_safeAreaBackgroundView.autoresizesSubviews = YES;
+		_safeAreaBackgroundView.hidden = true;
 
-    		[self.webView.superview addSubview:_safeAreaBackgroundView];
-    	}    	
-	}
+		[self.webView.superview addSubview:_safeAreaBackgroundView];
+	} 	
 }
 
 - (void)resizeViews {
@@ -718,6 +717,12 @@
 
         CGRect bf = self.bannerView.frame;
 
+        
+    	//If the ad is not showing turn the safeArea Background off
+        if(self.bannerView.hidden && ! _safeAreaBackgroundView.hidden){
+        	_safeAreaBackgroundView.hidden = true;
+        }
+
         // If the ad is not showing or the ad is hidden, we don't want to resize anything.
         UIView* parentView = self.bannerOverlap ? self.webView : [self.webView superview];
         BOOL adIsShowing = ([self.bannerView isDescendantOfView:parentView]) && (! self.bannerView.hidden);
@@ -746,6 +751,11 @@
                         bf.origin.y -= parentView.safeAreaInsets.bottom;
                         bf.size.width = wf.size.width - parentView.safeAreaInsets.left - parentView.safeAreaInsets.right;
                         wf.size.height -= parentView.safeAreaInsets.bottom;
+
+                        //If safeAreBackground was turned turned off, turn it back on
+                        if( _safeAreaBackgroundView.hidden ){
+        					_safeAreaBackgroundView.hidden = false;
+        				}
 
                         CGRect saf = _safeAreaBackgroundView.frame;
                         saf.origin.y = pr.size.height - parentView.safeAreaInsets.bottom;

--- a/src/ios/CDVAdMob.m
+++ b/src/ios/CDVAdMob.m
@@ -8,7 +8,6 @@
 #import "MainViewController.h"
 
 
-
 @interface CDVAdMob()
 
 - (void) __setOptions:(NSDictionary*) options;
@@ -106,7 +105,7 @@
     isRewardedVideoLoading = false;
     rewardedVideoLock = nil;
 
-    srand((unsigned int)time(NULL));
+    srand((unsigned int)time(NULL));  
 }
 
 - (void) setOptions:(CDVInvokedUrlCommand *)command {
@@ -531,7 +530,7 @@
     NSLog(@"__createBanner");
 
     // set background color to black
-    self.webView.superview.backgroundColor = [UIColor blackColor];
+    //self.webView.superview.backgroundColor = [UIColor blackColor];
     //self.webView.superview.tintColor = [UIColor whiteColor];
 
     if (!self.bannerView){
@@ -669,9 +668,10 @@
     //NSLog(@"super view: %d x %d", (int)pr.size.width, (int)pr.size.height);
 
     // iOS7 Hack, handle the Statusbar
-    BOOL isIOS7 = ([[UIDevice currentDevice].systemVersion floatValue] >= 7) && ([[UIDevice currentDevice].systemVersion floatValue] < 11);
-    CGRect sf = [[UIApplication sharedApplication] statusBarFrame];
-    CGFloat top = isIOS7 ? MIN(sf.size.height, sf.size.width) : 0.0;
+    //BOOL isIOS7 = ([[UIDevice currentDevice].systemVersion floatValue] >= 7);
+    //CGRect sf = [[UIApplication sharedApplication] statusBarFrame];
+    //CGFloat top = isIOS7 ? MIN(sf.size.height, sf.size.width) : 0.0;
+    float top = 0.0;
 
     if(! self.offsetTopBar) top = 0.0;
 
@@ -739,7 +739,8 @@
     //NSLog(@"superview: %d x %d, webview: %d x %d", (int) pr.size.width, (int) pr.size.height, (int) wf.size.width, (int) wf.size.height );
 }
 
-- (void)deviceOrientationChange:(NSNotification *)notification {
+- (void)deviceOrientationChange:(NSNotification *)notification {    
+    
     [self resizeViews];
 }
 

--- a/src/ios/CDVAdMob.m
+++ b/src/ios/CDVAdMob.m
@@ -740,7 +740,7 @@
     //NSLog(@"superview: %d x %d, webview: %d x %d", (int) pr.size.width, (int) pr.size.height, (int) wf.size.width, (int) wf.size.height );
 }
 
-- (void)deviceOrientationChange:(NSNotification *)notification {    
+- (void)deviceOrientationChange:(NSNotification *)notification {
     [self resizeViews];
 }
 

--- a/src/ios/CDVAdMob.m
+++ b/src/ios/CDVAdMob.m
@@ -753,9 +753,8 @@
                         wf.size.height -= parentView.safeAreaInsets.bottom;
 
                         //If safeAreBackground was turned turned off, turn it back on
-                        if( _safeAreaBackgroundView.hidden ){
-        					_safeAreaBackgroundView.hidden = false;
-        				}
+                        _safeAreaBackgroundView.hidden = false;
+        		
 
                         CGRect saf = _safeAreaBackgroundView.frame;
                         saf.origin.y = pr.size.height - parentView.safeAreaInsets.bottom;


### PR DESCRIPTION
The following changes address some concerns I had as mentioned in issue #186 and issue #218 . This also solves the problem @joe-scotto is having in issue #228 .  

I got rid of the iOS 7 hack altogether.  This really wasn't an iOS 7 hack, but rather a hack to make this plugin work with a feature of the statusbar plugin.  As I mentioned before, it is apples intention to have your app flood below the status bar.  It is very easy to add a div to the top of your webview or padding to the top of your header that moves your content below the statusbar.  See this link for instructions:
[https://blog.phonegap.com/displaying-a-phonegap-app-correctly-on-the-iphone-x-c4a85664c493](url)

I was able to create an addition sub view called _safeAreaBackgroundView that only gets initialized, sized, and positioned if the device is running iOS 11 or greater, the ad banner is at the bottom, and the ad banner doesn't overlay the webview.  I set the background color of this view to black.  We might be able to work on this in the future and allow the user to set a preference for the background color somewhere in their own code.  For now, I think black will be compatible with most people's devices.

None of my apps use banner ads at the top or banner ads that overlay.  There may need to be some additional work to make these types of ads position properly on the iPhoneX.  From what I can see now, all ads (overlay and not) at the top might be beneath the statusbar.  Also, ads at the bottom that overlay might need to be shifted up on the iPhoneX as well.

