### PR TITLE
Remove unnecessary @Override annotation causing build error for older play services versions

### DIFF
--- a/src/android/rewardvideo/RewardVideoListener.java
+++ b/src/android/rewardvideo/RewardVideoListener.java
@@ -86,8 +86,7 @@ class RewardVideoListener implements RewardedVideoAdListener {
         }
         executor.fireAdEvent("admob.rewardvideo.events.REWARD", data);
     }
-    
-    @Override
+
     public void onRewardedVideoCompleted() {
         executor.fireAdEvent("admob.rewardvideo.events.CLOSE");
     }


### PR DESCRIPTION
The callback method `onRewardedVideoCompleted()` has been added in Google Mobile Ads SDK version 12.0.0 for Android. We can check it in the release notes [here](https://developers.google.com/admob/android/rel-notes).

The `@Override` annotation will ensure that the callback is implemented in `RewardedVideoAdListener` implementation. It raises error with SDK versions below `12.0.0` as there is no such callback there.

Removing that `@Override` annotation will fix the issue for older SDK versions without causing any problems in newer versions.

Closes #244, closes #246 and closes #251.