### PR TITLE
Multiple fixes for iPhone X and Interstitials

### DIFF
--- a/src/ios/CDVAdMob.m
+++ b/src/ios/CDVAdMob.m
@@ -863,6 +863,7 @@
     if (self.interstitialView) {
         self.interstitialView.delegate = nil;
         self.interstitialView = nil;
+        [self resizeViews];
     }
 }
 

--- a/src/ios/CDVAdMob.m
+++ b/src/ios/CDVAdMob.m
@@ -733,6 +733,7 @@
                     wf.origin.y = bf.origin.y + bf.size.height;
                     
                     if (@available(iOS 11.0, *)) {
+                        bf.origin.y += parentView.safeAreaInsets.top;
                         wf.origin.y += parentView.safeAreaInsets.top;
                         bf.size.width = wf.size.width - parentView.safeAreaInsets.left - parentView.safeAreaInsets.right;
                         wf.size.height -= parentView.safeAreaInsets.top;

--- a/src/ios/CDVAdMob.m
+++ b/src/ios/CDVAdMob.m
@@ -723,9 +723,31 @@
                 if(bannerOverlap) {
                     wf.origin.y = top;
                     bf.origin.y = 0; // banner is subview of webview
+                    
+                    if (@available(iOS 11.0, *)) {
+                        bf.origin.y = parentView.safeAreaInsets.top;
+                        bf.size.width = wf.size.width - parentView.safeAreaInsets.left - parentView.safeAreaInsets.right;
+                    }
                 } else {
                     bf.origin.y = top;
                     wf.origin.y = bf.origin.y + bf.size.height;
+                    
+                    if (@available(iOS 11.0, *)) {
+                        wf.origin.y += parentView.safeAreaInsets.top;
+                        bf.size.width = wf.size.width - parentView.safeAreaInsets.left - parentView.safeAreaInsets.right;
+                        wf.size.height -= parentView.safeAreaInsets.top;
+
+                        //If safeAreBackground was turned turned off, turn it back on
+                        _safeAreaBackgroundView.hidden = false;
+
+                        CGRect saf = _safeAreaBackgroundView.frame;
+                        saf.origin.y = top;
+                        saf.size.width = pr.size.width;
+                        saf.size.height = parentView.safeAreaInsets.top;
+
+                        _safeAreaBackgroundView.frame = saf;
+                        _safeAreaBackgroundView.bounds = saf;
+                    }
                 }
 
             } else {
@@ -734,6 +756,11 @@
 
                 if( bannerOverlap ) {
                     bf.origin.y = wf.size.height - bf.size.height; // banner is subview of webview
+                    
+                    if (@available(iOS 11.0, *)) {
+                        bf.origin.y -= parentView.safeAreaInsets.bottom;
+                        bf.size.width = wf.size.width - parentView.safeAreaInsets.left - parentView.safeAreaInsets.right;
+                    }
                 } else {
                     bf.origin.y = pr.size.height - bf.size.height;
 


### PR DESCRIPTION
I had originally fixed the banner location issues on iPhone X for bottom banners only.  This new PR fixes banner locations on the iPhone X for top banners.  These changes make banner placement obey safe areas in iOS11.

I also included a change to adjust the webview after closing an interstitial ad so that banners are positioned correctly.