### PR TITLE
fix: Make plugin available for Ads SDK v17.0.0

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -29,10 +29,15 @@
     <dependency id="cordova-admob-sdk" version="~0.20.0" />
 
     <platform name="android">
+        <preference name="ADMOB_APP_ID" default=""/>
+
         <config-file parent="/manifest/application" target="AndroidManifest.xml">
             <activity android:name="com.google.android.gms.ads.AdActivity"
                 android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|uiMode|screenSize|smallestScreenSize"
                 android:theme="@android:style/Theme.Translucent" />
+            <meta-data
+                android:name="com.google.android.gms.ads.APPLICATION_ID"
+                android:value="$ADMOB_APP_ID"/>
         </config-file>
         <config-file parent="/*" target="AndroidManifest.xml">
             <uses-permission android:name="android.permission.INTERNET" />


### PR DESCRIPTION
fix #286

- Add a new preference (ADMOB_APP_ID - like mentioned in https://developers.google.com/admob/android/quick-start#update_your_androidmanifestxml)

- Update the android-manifest.xml by using the preference