### PR TITLE
add GADApplicationIdentifier and GAdIsAdManagerApp to Info.plist

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -65,6 +65,14 @@
     </platform>
 
     <platform name="ios">
+        <config-file target="*-Info.plist" parent="GADApplicationIdentifier">
+            <string>$ADMOB_APP_ID</string>
+        </config-file>
+
+        <config-file target="*-Info.plist" parent="GADIsAdManagerApp">
+            <true />
+        </config-file>
+
         <config-file parent="/*" target="config.xml">
             <feature name="AdMob">
                 <param name="ios-package" value="CDVAdMob" />


### PR DESCRIPTION
Programmatically add both the `GADApplicationIdentifier` and `GADIsAdManagerApp` to the Info.plist file.