### PR TITLE
(FEAT) Sets GADRewardBasedVideoAd.userIdentifier= AdExtras.userId val…

### DIFF
--- a/src/ios/CDVAdMob.h
+++ b/src/ios/CDVAdMob.h
@@ -59,6 +59,7 @@
 
 @property (nonatomic, retain) NSString* gender;
 @property (nonatomic, retain) NSString* forChild;
+@property(nonatomic, copy, nullable) NSString *userId;
 
 - (void) setOptions:(CDVInvokedUrlCommand *)command;
 

--- a/src/ios/CDVAdMob.m
+++ b/src/ios/CDVAdMob.m
@@ -33,7 +33,7 @@
 
 @synthesize publisherId, interstitialAdId, rewardVideoId, adSize;
 @synthesize bannerAtTop, bannerOverlap, offsetTopBar;
-@synthesize isTesting, adExtras;
+@synthesize isTesting, adExtras,userId;
 
 @synthesize bannerIsVisible, bannerIsInitialized;
 @synthesize bannerShow, autoShow, autoShowBanner, autoShowInterstitial, autoShowRewardVideo;
@@ -98,6 +98,7 @@
 
     gender = nil;
     forChild = nil;
+    userId = @"";
 
     isRewardedVideoLoading = false;
     rewardedVideoLock = nil;
@@ -404,6 +405,8 @@
                 self.rewardVideoView = [GADRewardBasedVideoAd sharedInstance];
                 self.rewardVideoView.delegate = self;
 
+                NSString* myNewString = [NSString stringWithFormat:@"%@", self.userId];
+                [GADRewardBasedVideoAd sharedInstance].userIdentifier = myNewString;
                 [self.rewardVideoView loadRequest:[GADRequest request] withAdUnitID:self.rewardVideoId];
             }
         }
@@ -506,6 +509,11 @@
     NSDictionary* dict = [options objectForKey:OPT_AD_EXTRAS];
     if (dict) {
         adExtras = dict;
+        NSString* str2 = nil;
+        str2 = [adExtras objectForKey:@"userId"];
+        if (str2) {
+            self.userId = str2;
+        }
     }
 
     str = [options objectForKey:OPT_AUTO_SHOW];


### PR DESCRIPTION
Only for **iOS**:
This modification allows sending userId in **SSV** callbacks url:
Sets userIdentifier in GADRewardBasedVideoAd, with AdExtras.userId value.
For more information about server callback parameters  [AdMob SDK documentation ](https://developers.google.com/admob/ios/rewarded-video-ssv?hl=en#ssv_callback_parameters)